### PR TITLE
Make backup folder if it doesn't exist

### DIFF
--- a/__test__/backup.test.ts
+++ b/__test__/backup.test.ts
@@ -126,6 +126,34 @@ describe("Backup", function () {
       expect(backup.log.error).toHaveBeenCalledTimes(0);
       expect(backup.log.warn).toHaveBeenCalledTimes(0);
     });
+
+    it("should make backup directory with relative path", async () => {
+      const relativePath = "relativePath";
+      when(spyOnsSettingsValue)
+        .calledWith("path")
+        .mockImplementation(() => Promise.resolve(relativePath));
+      await backup.loadBackupPath();
+
+      expect(fs.existsSync(backup.backupBasePath)).toBe(true);
+      expect(backup.log.error).toHaveBeenCalledTimes(0);
+      expect(backup.log.warn).toHaveBeenCalledTimes(0);
+
+      fs.removeSync(backup.backupBasePath);
+    });
+
+    it("should make backup directory with absolute path", async () => {
+      const absolutePath = path.join(__dirname, "absolute_path_to_folder1");
+      when(spyOnsSettingsValue)
+        .calledWith("path")
+        .mockImplementation(() => Promise.resolve(absolutePath));
+      await backup.loadBackupPath();
+
+      expect(fs.existsSync(backup.backupBasePath)).toBe(true);
+      expect(backup.log.error).toHaveBeenCalledTimes(0);
+      expect(backup.log.warn).toHaveBeenCalledTimes(0);
+
+      fs.removeSync(backup.backupBasePath);
+    });
   });
 
   describe("Div", function () {

--- a/src/Backup.ts
+++ b/src/Backup.ts
@@ -182,6 +182,12 @@ class Backup {
     );
   }
 
+  public async makeBackupDir() {
+    if (this.backupBasePath !== null && !fs.existsSync(this.backupBasePath)) {
+      await fs.promises.mkdir(this.backupBasePath, { recursive: true });
+    }
+  }
+
   private async loadBackupPath() {
     this.log.verbose("loadBackupPath");
     const pathSetting = await joplin.settings.value("path");
@@ -199,6 +205,7 @@ class Backup {
     if (path.normalize(profileDir) === this.backupBasePath) {
       this.backupBasePath = null;
     }
+    await this.makeBackupDir();
   }
 
   public async loadSettings() {


### PR DESCRIPTION
This PR adds functionality to create backup folder / path given by user if it does not exist. I have added 2 additional tests for this.

While running the tests though, following test was failing sometimes.
`Test sevenZip › passwordProtected`