### PR TITLE
Refuse to overwrite any directory containing the home directory or the profile directory

### DIFF
--- a/__test__/backup.test.ts
+++ b/__test__/backup.test.ts
@@ -168,7 +168,7 @@ describe("Backup", function () {
     });
 
     it(`relative paths`, async () => {
-      const backupPath = "../";
+      const backupPath = "../foo";
       /* prettier-ignore */
       when(spyOnsSettingsValue)
       .calledWith("path").mockImplementation(() => Promise.resolve(backupPath));

--- a/__test__/backup.test.ts
+++ b/__test__/backup.test.ts
@@ -200,6 +200,10 @@ describe("Backup", function () {
       path.dirname(os.homedir()),
       path.join(os.homedir(), "Desktop"),
       path.join(os.homedir(), "Documents"),
+      
+      // Avoid including system-specific paths here. For example,
+      // testing with "C:\Windows" fails on POSIX systems because it is interpreted
+      // as a relative path.
     ])(
       "should not allow backup path (%s) to be an important system directory",
       async (path) => {

--- a/__test__/help.test.ts
+++ b/__test__/help.test.ts
@@ -1,3 +1,4 @@
+import * as path from "path";
 import { helper } from "../src/helper";
 
 describe("Test helper", function () {
@@ -164,9 +165,25 @@ describe("Test helper", function () {
     ["a", "/a", false],
     ["/a/b", "/b/c", false],
   ])(
-    "isSubdirectoryOrEqual (is %s the parent of %s?)",
+    "isSubdirectoryOrEqual with POSIX paths(is %s the parent of %s?)",
     (path1, path2, expected) => {
-      expect(helper.isSubdirectoryOrEqual(path1, path2)).toBe(expected);
+      expect(helper.isSubdirectoryOrEqual(path1, path2, path.posix)).toBe(
+        expected
+      );
+    }
+  );
+
+  test.each([
+    ["C:\\Users\\User\\", "C:\\Users\\User\\", true],
+    ["D:\\Users\\User\\", "C:\\Users\\User\\", false],
+    ["C:\\Users\\Userr\\", "C:\\Users\\User\\", false],
+    ["C:\\Users\\User\\", "C:\\Users\\User\\.config\\joplin-desktop", true],
+  ])(
+    "isSubdirectoryOrEqual with Windows paths (is %s the parent of %s?)",
+    (path1, path2, expected) => {
+      expect(helper.isSubdirectoryOrEqual(path1, path2, path.win32)).toBe(
+        expected
+      );
     }
   );
 });

--- a/__test__/help.test.ts
+++ b/__test__/help.test.ts
@@ -146,4 +146,14 @@ describe("Test helper", function () {
       ).toBe(testCase.expected);
     }
   });
+
+  test.each([
+    [ "/tmp/this/is/a/test", "/tmp/this/is/a/test", true ],
+    [ "/tmp/test", "/tmp/test///", true ],
+    [ "/tmp/te", "/tmp/test", false ],
+    [ "a", "/a", false ],
+    [ "/a/b", "/b/c", false ],
+  ])("pathsEquivalent (%s ?= %s)", (path1, path2, expected) => {
+    expect(helper.pathsEquivalent(path1, path2)).toBe(expected);
+  });
 });

--- a/__test__/help.test.ts
+++ b/__test__/help.test.ts
@@ -148,12 +148,25 @@ describe("Test helper", function () {
   });
 
   test.each([
-    [ "/tmp/this/is/a/test", "/tmp/this/is/a/test", true ],
-    [ "/tmp/test", "/tmp/test///", true ],
-    [ "/tmp/te", "/tmp/test", false ],
-    [ "a", "/a", false ],
-    [ "/a/b", "/b/c", false ],
-  ])("pathsEquivalent (%s ?= %s)", (path1, path2, expected) => {
-    expect(helper.pathsEquivalent(path1, path2)).toBe(expected);
-  });
+    // Equality
+    ["/tmp/this/is/a/test", "/tmp/this/is/a/test", true],
+    ["/tmp/test", "/tmp/test///", true],
+
+    // Subdirectories
+    ["/tmp", "/tmp/test", true],
+    ["/tmp/", "/tmp/test", true],
+    ["/tmp/", "/tmp/..test", true],
+    ["/tmp/test", "/tmp/", false],
+
+    // Different directories
+    ["/tmp/", "/tmp/../test", false],
+    ["/tmp/te", "/tmp/test", false],
+    ["a", "/a", false],
+    ["/a/b", "/b/c", false],
+  ])(
+    "isSubdirectoryOrEqual (is %s the parent of %s?)",
+    (path1, path2, expected) => {
+      expect(helper.isSubdirectoryOrEqual(path1, path2)).toBe(expected);
+    }
+  );
 });

--- a/__test__/help.test.ts
+++ b/__test__/help.test.ts
@@ -165,7 +165,7 @@ describe("Test helper", function () {
     ["a", "/a", false],
     ["/a/b", "/b/c", false],
   ])(
-    "isSubdirectoryOrEqual with POSIX paths(is %s the parent of %s?)",
+    "isSubdirectoryOrEqual with POSIX paths (is %s the parent of %s?)",
     (path1, path2, expected) => {
       expect(helper.isSubdirectoryOrEqual(path1, path2, path.posix)).toBe(
         expected

--- a/src/Backup.ts
+++ b/src/Backup.ts
@@ -4,6 +4,7 @@ import joplin from "api";
 import * as path from "path";
 import backupLogging from "electron-log";
 import * as fs from "fs-extra";
+import * as os from "os";
 import { sevenZip } from "./sevenZip";
 import * as moment from "moment";
 import { helper } from "./helper";
@@ -288,11 +289,16 @@ class Backup {
       }
     }
 
-    if (path.normalize(profileDir) === this.backupBasePath) {
+    const handleInvalidPath = async (errorId: string) => {
+      const invalidBackupPath = this.backupBasePath;
       this.backupBasePath = null;
-      await this.showError(
-        i18n.__("msg.error.backupPathJoplinDir", path.normalize(profileDir))
-      );
+      await this.showError(i18n.__(errorId, invalidBackupPath));
+    };
+
+    if (helper.pathsEquivalent(profileDir, this.backupBasePath)) {
+      await handleInvalidPath("msg.error.backupPathJoplinDir");
+    } else if (helper.pathsEquivalent(os.homedir(), this.backupBasePath)) {
+      await handleInvalidPath("msg.error.backupPathHomeDir");
     }
   }
 

--- a/src/Backup.ts
+++ b/src/Backup.ts
@@ -295,10 +295,10 @@ class Backup {
       await this.showError(i18n.__(errorId, invalidBackupPath));
     };
 
-    if (helper.pathsEquivalent(profileDir, this.backupBasePath)) {
-      await handleInvalidPath("msg.error.backupPathJoplinDir");
-    } else if (helper.pathsEquivalent(os.homedir(), this.backupBasePath)) {
-      await handleInvalidPath("msg.error.backupPathHomeDir");
+    if (helper.isSubdirectoryOrEqual(this.backupBasePath, os.homedir())) {
+      await handleInvalidPath("msg.error.backupPathContainsHomeDir");
+    } else if (helper.isSubdirectoryOrEqual(this.backupBasePath, profileDir)) {
+      await handleInvalidPath("msg.error.backupPathContainsJoplinDir");
     }
   }
 

--- a/src/Backup.ts
+++ b/src/Backup.ts
@@ -289,16 +289,28 @@ class Backup {
       }
     }
 
-    const handleInvalidPath = async (errorId: string) => {
-      const invalidBackupPath = this.backupBasePath;
-      this.backupBasePath = null;
-      await this.showError(i18n.__(errorId, invalidBackupPath));
-    };
+    // Creating a backup can overwrite the backup directory. Thus,
+    // we mark several system and user directories as not-overwritable.
+    const systemDirectories = [
+      profileDir,
+      os.homedir(),
 
-    if (helper.isSubdirectoryOrEqual(this.backupBasePath, os.homedir())) {
-      await handleInvalidPath("msg.error.backupPathContainsHomeDir");
-    } else if (helper.isSubdirectoryOrEqual(this.backupBasePath, profileDir)) {
-      await handleInvalidPath("msg.error.backupPathContainsJoplinDir");
+      path.join(os.homedir(), "Desktop"),
+      path.join(os.homedir(), "Documents"),
+      path.join(os.homedir(), "Downloads"),
+      path.join(os.homedir(), "Pictures"),
+      "C:\\Windows",
+    ];
+
+    for (const systemDirectory of systemDirectories) {
+      if (helper.isSubdirectoryOrEqual(this.backupBasePath, systemDirectory)) {
+        const invalidBackupPath = this.backupBasePath;
+        this.backupBasePath = null;
+        await this.showError(
+          i18n.__("msg.error.backupPathContainsImportantDir", invalidBackupPath)
+        );
+        break;
+      }
     }
   }
 

--- a/src/Backup.ts
+++ b/src/Backup.ts
@@ -299,8 +299,11 @@ class Backup {
       path.join(os.homedir(), "Documents"),
       path.join(os.homedir(), "Downloads"),
       path.join(os.homedir(), "Pictures"),
-      "C:\\Windows",
     ];
+
+    if (os.platform() === "win32") {
+      systemDirectories.push("C:\\Windows");
+    }
 
     for (const systemDirectory of systemDirectories) {
       if (helper.isSubdirectoryOrEqual(this.backupBasePath, systemDirectory)) {

--- a/src/helper.ts
+++ b/src/helper.ts
@@ -70,7 +70,13 @@ export namespace helper {
   // Doesn't resolve simlinks
   // See https://stackoverflow.com/questions/44892672/how-to-check-if-two-paths-are-the-same-in-npm
   // for possible alternative implementations.
-  export function isSubdirectoryOrEqual(parent: string, possibleChild: string) {
+  export function isSubdirectoryOrEqual(
+    parent: string,
+    possibleChild: string,
+
+    // Testing only
+    pathModule: typeof path = path
+  ) {
     // Appending path.sep to handle this case:
     //   parent: /a/b/test
     //   possibleChild: /a/b/test2
@@ -79,8 +85,8 @@ export namespace helper {
     //
     // Note that .resolve removes trailing slashes.
     //
-    const normalizedParent = path.resolve(parent) + path.sep;
-    const normalizedChild = path.resolve(possibleChild) + path.sep;
+    const normalizedParent = pathModule.resolve(parent) + pathModule.sep;
+    const normalizedChild = pathModule.resolve(possibleChild) + pathModule.sep;
 
     return normalizedChild.startsWith(normalizedParent);
   }

--- a/src/helper.ts
+++ b/src/helper.ts
@@ -1,4 +1,5 @@
 import joplin from "api";
+import * as path from "path";
 
 export namespace helper {
   export async function validFileName(fileName: string) {
@@ -64,5 +65,11 @@ export namespace helper {
     }
 
     return result;
+  }
+
+  export function pathsEquivalent(path1: string, path2: string) {
+    // We use `resolve` and not `normalize` because `resolve` removes trailing
+    // slashes, while `normalize` does not.
+    return path.resolve(path1) === path.resolve(path2);
   }
 }

--- a/src/helper.ts
+++ b/src/helper.ts
@@ -67,9 +67,21 @@ export namespace helper {
     return result;
   }
 
-  export function pathsEquivalent(path1: string, path2: string) {
-    // We use `resolve` and not `normalize` because `resolve` removes trailing
-    // slashes, while `normalize` does not.
-    return path.resolve(path1) === path.resolve(path2);
+  // Doesn't resolve simlinks
+  // See https://stackoverflow.com/questions/44892672/how-to-check-if-two-paths-are-the-same-in-npm
+  // for possible alternative implementations.
+  export function isSubdirectoryOrEqual(parent: string, possibleChild: string) {
+    // Appending path.sep to handle this case:
+    //   parent: /a/b/test
+    //   possibleChild: /a/b/test2
+    // "/a/b/test2".startsWith("/a/b/test") -> true, but
+    // "/a/b/test2/".startsWith("/a/b/test/") -> false
+    //
+    // Note that .resolve removes trailing slashes.
+    //
+    const normalizedParent = path.resolve(parent) + path.sep;
+    const normalizedChild = path.resolve(possibleChild) + path.sep;
+
+    return normalizedChild.startsWith(normalizedParent);
   }
 }

--- a/src/locales/de_DE.json
+++ b/src/locales/de_DE.json
@@ -13,7 +13,7 @@
       "Backup": "Backup Fehler für %s: %s",
       "fileCopy": "Fehler beim kopieren von Datei/Ordner in %s: %s",
       "deleteFile": "Fehler beim löschen von Datei/Ordner in %s: %s",
-      "backupPathJoplinDir": "Als Sicherungs Pfad wurde das Joplin profile Verzeichniss (%s) ohne Unterordner ausgewählt, dies ist nicht erlaubt!",
+      "backupPathContainsJoplinDir": "Als Sicherungs Pfad wurde das Joplin profile Verzeichniss (%s) ohne Unterordner ausgewählt, dies ist nicht erlaubt!",
       "BackupSetNotSupportedChars": "Der Name des Backup-Sets enthält nicht zulässige Zeichen ( %s )!",
       "passwordDoubleQuotes": "Das Passwort enthält \" (Doppelte Anführungszeichen), diese sind wegen eines Bugs nicht erlaubt. Der Passwortschutz für die Backups wurde deaktivert!"
     }

--- a/src/locales/de_DE.json
+++ b/src/locales/de_DE.json
@@ -13,7 +13,6 @@
       "Backup": "Backup Fehler für %s: %s",
       "fileCopy": "Fehler beim kopieren von Datei/Ordner in %s: %s",
       "deleteFile": "Fehler beim löschen von Datei/Ordner in %s: %s",
-      "backupPathContainsJoplinDir": "Als Sicherungs Pfad wurde das Joplin profile Verzeichniss (%s) ohne Unterordner ausgewählt, dies ist nicht erlaubt!",
       "BackupSetNotSupportedChars": "Der Name des Backup-Sets enthält nicht zulässige Zeichen ( %s )!",
       "passwordDoubleQuotes": "Das Passwort enthält \" (Doppelte Anführungszeichen), diese sind wegen eines Bugs nicht erlaubt. Der Passwortschutz für die Backups wurde deaktivert!"
     }

--- a/src/locales/en_US.json
+++ b/src/locales/en_US.json
@@ -14,6 +14,7 @@
       "fileCopy": "Error on file/folder copy in %s: %s",
       "deleteFile": "Error on file/folder delete in %s: %s",
       "backupPathJoplinDir": "The backup path is the Joplin profile directory (%s) without subfolders, this is not allowed!",
+      "backupPathHomeDir": "The backup path is the home directory (%s). Either enable \"createSubfolders\" or choose a different backup directory.",
       "BackupSetNotSupportedChars": "Backup set name does contain not allowed characters ( %s )!",
       "passwordDoubleQuotes": "Password contains \" (double quotes), these are not allowed because of a bug. Password protection for the backup is deactivated!"
     }

--- a/src/locales/en_US.json
+++ b/src/locales/en_US.json
@@ -13,8 +13,8 @@
       "Backup": "Backup error for %s: %s",
       "fileCopy": "Error on file/folder copy in %s: %s",
       "deleteFile": "Error on file/folder delete in %s: %s",
-      "backupPathJoplinDir": "The backup path is the Joplin profile directory (%s) without subfolders, this is not allowed!",
-      "backupPathHomeDir": "The backup path is the home directory (%s). Either enable \"createSubfolders\" or choose a different backup directory.",
+      "backupPathContainsJoplinDir": "The backup path is or contains the Joplin profile directory (%s) without subfolders, this is not allowed!",
+      "backupPathContainsHomeDir": "The backup path is or contains the home directory (%s). Without enabling the subfolder setting, this is not allowed!",
       "BackupSetNotSupportedChars": "Backup set name does contain not allowed characters ( %s )!",
       "passwordDoubleQuotes": "Password contains \" (double quotes), these are not allowed because of a bug. Password protection for the backup is deactivated!"
     }

--- a/src/locales/en_US.json
+++ b/src/locales/en_US.json
@@ -13,8 +13,7 @@
       "Backup": "Backup error for %s: %s",
       "fileCopy": "Error on file/folder copy in %s: %s",
       "deleteFile": "Error on file/folder delete in %s: %s",
-      "backupPathContainsJoplinDir": "The backup path is or contains the Joplin profile directory (%s) without subfolders, this is not allowed!",
-      "backupPathContainsHomeDir": "The backup path is or contains the home directory (%s). Without enabling the subfolder setting, this is not allowed!",
+      "backupPathContainsImportantDir": "The backup path is or contains an important directory (%s) that could be overwritten by a backup. Without enabling the subfolder setting, this is not allowed!",
       "BackupSetNotSupportedChars": "Backup set name does contain not allowed characters ( %s )!",
       "passwordDoubleQuotes": "Password contains \" (double quotes), these are not allowed because of a bug. Password protection for the backup is deactivated!"
     }


### PR DESCRIPTION
# Summary

Prevents the plugin from overwriting `os.homedir()` or the Joplin profile directory.

## Rationale

https://github.com/laurent22/joplin/issues/9857 suggests backing up to a subdirectory of the home directory by default. One way to do this is to set Simple Backup's `path` setting to the HOME directory.

Without additional checks, this could be dangerous if a user unchecks the "create subfolder" option.

## Alternatives

- Don't overwrite any directory that contains the profile directory

# Testing

This pull request has a related automated test. However, this only tests one part of this pull request.

To test the pull request manually,
1. Create a new user account
2. Build the plugin from this branch and load it as a development plugin
3. Start Joplin
4. Set the backup path to the home directory
5. Create a backup
6. Disable subfolder creation
7. Try to create a backup
8. Set the backup path to the `.config` directory (e.g. `/home/user/.config/`)
9. Try to create a backup
10. Set the backup path to the profile directory
11. Try to create a backup

This has been tested successfully with commit 2f8ccdab529566988b1a840b0ae98c60bc79133c on OpenSUSE 20240202 with Joplin 2.14.12.