### PR TITLE
Add a README.md file to the backup directory

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "husky": "^6.0.0",
     "jest": "^27.0.4",
     "jest-when": "^3.3.1",
-    "joplinplugindevtools": "^1.0.15",
+    "joplinplugindevtools": "^1.0.16",
     "lint-staged": "^11.0.0",
     "mime": "^2.5.2",
     "on-build-webpack": "^0.1.0",

--- a/src/Backup.ts
+++ b/src/Backup.ts
@@ -477,6 +477,7 @@ class Backup {
         await this.backupNotebooks();
 
         const backupDst = await this.makeBackupSet();
+        await this.writeReadme(backupDst);
 
         await joplin.settings.setValue(
           "lastBackup",
@@ -682,6 +683,16 @@ class Backup {
     } else {
       return false;
     }
+  }
+
+  private async writeReadme(backupFolder: string) {
+    const readmePath = path.join(backupFolder, "README.md");
+    this.log.info("writeReadme to", readmePath);
+    const readmeText = i18n.__(
+      "backupReadme",
+      this.backupStartTime.toLocaleString()
+    );
+    await fs.writeFile(readmePath, readmeText, "utf8");
   }
 
   private async backupNotebooks() {

--- a/src/Backup.ts
+++ b/src/Backup.ts
@@ -477,8 +477,8 @@ class Backup {
         await this.backupNotebooks();
 
         const backupDst = await this.makeBackupSet();
-        await this.writeReadme(backupDst);
 
+        await this.writeReadme(this.backupBasePath);
         await joplin.settings.setValue(
           "lastBackup",
           this.backupStartTime.getTime()

--- a/src/locales/en_US.json
+++ b/src/locales/en_US.json
@@ -86,6 +86,7 @@
       "description": "Execute command when backup is finished"
     }
   },
+  "backupReadme": "# Joplin Backup\n\nThe backups in this folder were created with the Simple Backup plugin for Joplin. The most recent backup was created on %s.\n\nSee the [Simple Backup documentation](https://joplinapp.org/plugins/plugin/io.github.jackgruber.backup/#restore) for information about how to restore from this backup.",
   "command": {
     "createBackup": "Create backup"
   }

--- a/src/locales/en_US.json
+++ b/src/locales/en_US.json
@@ -86,7 +86,7 @@
       "description": "Execute command when backup is finished"
     }
   },
-  "backupReadme": "# Joplin Backup\n\nThe backups in this folder were created with the Simple Backup plugin for Joplin. The most recent backup was created on %s.\n\nSee the [Simple Backup documentation](https://joplinapp.org/plugins/plugin/io.github.jackgruber.backup/#restore) for information about how to restore from this backup.",
+  "backupReadme": "# Joplin Backup\n\nThis folder contains one or more backups of data from the Joplin note taking application. The most recent backup was created on %s.\n\nSee the [Simple Backup documentation](https://joplinapp.org/plugins/plugin/io.github.jackgruber.backup/#restore) for information about how to restore from this backup.",
   "command": {
     "createBackup": "Create backup"
   }


### PR DESCRIPTION
# Summary

Adds a README.md file to the root backup directory that links to Simple Backup's README.

Example directory structure:
![all_notebooks, profile, and README all in the same folder](https://github.com/JackGruber/joplin-plugin-backup/assets/46334387/53afb650-520e-48f2-9237-8722ccecbc9e)

Example README content:
```markdown
# Joplin Backup

This folder contains one or more backups of data from the Joplin note taking application. The most recent backup was created on 2/14/2024, 4:31:21 PM.

See the [Simple Backup documentation](https://joplinapp.org/plugins/plugin/io.github.jackgruber.backup/#restore) for information about how to restore from this backup.
```

# Notes

- Does not commit changes to `package.json`
- Should adding a README file to the backup directory be a setting?